### PR TITLE
Fix npm release repair workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,26 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag whose npm package needs repair
+        required: true
+        type: string
 
 jobs:
   verify-release-inputs:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && startsWith(inputs.release_tag, 'v'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Verify tag matches package versions
         env:
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
           expected="${TAG_NAME#v}"
@@ -130,16 +137,18 @@ jobs:
   publish-npm:
     name: Publish TypeScript (npm)
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: verify-release-inputs
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Check npm for existing version
         id: npm_check


### PR DESCRIPTION
## What changed

- run the npm publisher on Node 24 so `npm@latest` is supported
- add a required `release_tag` input for manual npm repair runs
- check out and verify the existing tag before publishing
- keep every non-npm registry job disabled during a manual repair

## Why

The `v0.1.17` release used Node 20 and then installed npm 12, which requires a newer Node runtime. The other package registries published successfully, so moving the tag or replaying the entire release would be unnecessarily risky.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `bash scripts/update-local-hashes.sh`
- `git diff --exit-code -- hashes/local-hashes.json`
