### PR TITLE
Fix npm publisher toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,11 +163,6 @@ jobs:
       - name: Debug OIDC env
         run: |
           env | grep ACTIONS_ID_TOKEN || true
-      - name: Upgrade npm
-        run: |
-          npm -v
-          npm install -g npm@latest
-          npm -v
       - name: Clear npm auth
         run: |
           rm -f ~/.npmrc


### PR DESCRIPTION
## What changed

Removed the `npm@latest` global upgrade from the npm release job. The Node 24 runner already includes npm 11.16.0, which supports trusted publishing and provenance.

## Why

npm 12.0.0 installed incompletely on the hosted runner and failed at publish time because its `sigstore` module was missing. Using the bundled npm avoids mutating the runner toolchain immediately before publishing.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- local release hash regeneration produced no diff
